### PR TITLE
feature: Enable use in docker/julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,8 @@
 [deps]
 CSP11 = "48eaa45b-cddd-4e20-968f-8db8a6d464dd"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeoEnergyIO = "3b1dd628-313a-45bb-9d8d-8f3c48dcb5d4"
 HYPRE = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
 Jutul = "2b460a1a-8a2b-45b2-b125-b5c536396eb9"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,25 @@ You can now run the example:
 ```julia
 include("run_mrst_grid_spe11.jl")
 ```
+
+## Running in docker
+
+To run it inside a [Docker](https://docs.docker.com/desktop/) image, either build the image described uner _docker/jutul-spe11csp-juliaimg.Dockerfile_ or pull it from public [docker repository](https://hub.docker.com)
+
+```bash
+docker build --build-arg VERSION=v0 -t jutul-juliaimg-spe11csp -f jutul-spe11csp-juliaimg.Dockerfile .
+```
+
+or
+
+```bash
+docker push jafranc/jutul-juliaimg-spe11csp:latest
+```
+
+Then you can run it
+
+```bash
+docker run -it --rm -v /path/to/output:/tmp image_name julia -e "import Pkg;Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=\"/opt/spe11csp/CSP11\");include(\"docker_run_mrst_grid_spe11.jl\")"
+```
+
+where _image_name_ is to be replaced either by name taken during local build step (suggested above _jutul-juliaimg-spe11csp_) or by pulled image name _jafranc/jutul-juliaimg-spe11csp_. _/path/to/output_ to be replaced by the path to a local folder. Note that generated results will be root-owned as per vanilla docker logic. 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ or
 docker push jafranc/jutul-juliaimg-spe11csp:latest
 ```
 
-Then, as docker environement cannot easily be used with Cairo-GUI, _Project.toml_ has to be adjusted discarding inaccessible deps. It is done under the folder _docker/Project.toml_.
+Then, as docker environement cannot easily be used with Cairo-GUI, _Project.toml_ has to be adjusted discarding inaccessible deps. It is done under the folder _docker/Project.toml_ and copied into root in the docker image building step.
 
 Eventually you can run it
 
 ```bash
-docker run -it --rm -v /path/to/output:/tmp image_name julia -e "import Pkg;Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=\"/opt/spe11csp/CSP11/docker\");include(\"docker_run_mrst_grid_spe11.jl\")"
+docker run -it --rm -v /path/to/output:/tmp image_name julia -e "import Pkg;Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=\"/opt/spe11csp/CSP11\");include(\"docker_run_mrst_grid_spe11.jl\")"
 ```
 
 where _image_name_ is to be replaced either by name taken during local build step (suggested above _jutul-juliaimg-spe11csp_) or by pulled image name _jafranc/jutul-juliaimg-spe11csp_. _/path/to/output_ to be replaced by the path to a local folder. Note that generated results will be root-owned as per vanilla docker logic. 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ or
 docker push jafranc/jutul-juliaimg-spe11csp:latest
 ```
 
-Then you can run it
+Then, as docker environement cannot easily be used with Cairo-GUI, _Project.toml_ has to be adjusted discarding inaccessible deps. It is done under the folder _docker/Project.toml_.
+
+Eventually you can run it
 
 ```bash
-docker run -it --rm -v /path/to/output:/tmp image_name julia -e "import Pkg;Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=\"/opt/spe11csp/CSP11\");include(\"docker_run_mrst_grid_spe11.jl\")"
+docker run -it --rm -v /path/to/output:/tmp image_name julia -e "import Pkg;Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=\"/opt/spe11csp/CSP11/docker\");include(\"docker_run_mrst_grid_spe11.jl\")"
 ```
 
 where _image_name_ is to be replaced either by name taken during local build step (suggested above _jutul-juliaimg-spe11csp_) or by pulled image name _jafranc/jutul-juliaimg-spe11csp_. _/path/to/output_ to be replaced by the path to a local folder. Note that generated results will be root-owned as per vanilla docker logic. 

--- a/docker/Project.toml
+++ b/docker/Project.toml
@@ -1,10 +1,8 @@
 [deps]
 CSP11 = "48eaa45b-cddd-4e20-968f-8db8a6d464dd"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeoEnergyIO = "3b1dd628-313a-45bb-9d8d-8f3c48dcb5d4"
 HYPRE = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
 Jutul = "2b460a1a-8a2b-45b2-b125-b5c536396eb9"

--- a/docker/jutul-spe11csp-juliaimg.Dockerfile
+++ b/docker/jutul-spe11csp-juliaimg.Dockerfile
@@ -11,19 +11,10 @@ RUN apt install -y openssh-server ca-certificates vim
 
 FROM system_stage AS spe11csp_stage
 
-#ENV SPE_CASE=a
-#ENV INPUT_PATH=/opt/spe11csp/examples/
-#ENV CASEFILE=csp11${SPE_CASE}
-
-#RUN apt install -y python3 python3-venv python3-pip git
 RUN git clone https://github.com/jafranc/CSP11_JutulDarcy.jl -b feat/docker ${SPE11_DIR}
 
 WORKDIR ${SPE11_DIR}
 RUN git-lfs install
 RUN git-lfs pull 
+RUN cp -v docker/Project.toml .
 
-#RUN julia --project=${SPE11_DIR} \
-#	-e "import Pkg; Pkg.develop(path=\"${SPE11_DIR}/CSP11\");Pkg.instantiate();"
-
-#CMD ["julia","--project=\".\"" ,"-e", "\"import Pkg;Pkg.instantiate();Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=./CSP11);include(\"docker_run_mrst_grid_spe11.jl\");\""]
-#CMD ["sh", "-c", "/usr/local/bin/pyopmcsp11 -i /opt/spe11csp/examples/csp11${SPE_CASE}.txt -o output_csp11${SPE_CASE}"]

--- a/docker/jutul-spe11csp-juliaimg.Dockerfile
+++ b/docker/jutul-spe11csp-juliaimg.Dockerfile
@@ -1,0 +1,29 @@
+ARG VERSION
+
+
+FROM julia:${VERSION} AS system_stage
+
+ARG SPE11_DIR=/opt/spe11csp
+
+RUN apt update
+RUN apt install -y git git-lfs
+RUN apt install -y openssh-server ca-certificates vim
+
+FROM system_stage AS spe11csp_stage
+
+#ENV SPE_CASE=a
+#ENV INPUT_PATH=/opt/spe11csp/examples/
+#ENV CASEFILE=csp11${SPE_CASE}
+
+#RUN apt install -y python3 python3-venv python3-pip git
+RUN git clone https://github.com/jafranc/CSP11_JutulDarcy.jl -b feat/docker ${SPE11_DIR}
+
+WORKDIR ${SPE11_DIR}
+RUN git-lfs install
+RUN git-lfs pull 
+
+#RUN julia --project=${SPE11_DIR} \
+#	-e "import Pkg; Pkg.develop(path=\"${SPE11_DIR}/CSP11\");Pkg.instantiate();"
+
+#CMD ["julia","--project=\".\"" ,"-e", "\"import Pkg;Pkg.instantiate();Pkg.add([\"Jutul\",\"JutulDarcy\",\"HYPRE\"]);Pkg.develop(path=./CSP11);include(\"docker_run_mrst_grid_spe11.jl\");\""]
+#CMD ["sh", "-c", "/usr/local/bin/pyopmcsp11 -i /opt/spe11csp/examples/csp11${SPE_CASE}.txt -o output_csp11${SPE_CASE}"]

--- a/docker_run_mrst_grid_spe11.jl
+++ b/docker_run_mrst_grid_spe11.jl
@@ -1,0 +1,26 @@
+using Jutul, JutulDarcy, HYPRE, CSP11
+
+basename = "cPEBI_2640x380"
+basename = "cPEBI_819x117"
+basename = "horizon-cut_100x50"
+
+case, name = setup_spe11_caseb_from_mrst_grid(basename, thermal = true);
+pth = jutul_output_path(name, subfolder = "csp11")
+domain = reservoir_domain(case.model)
+
+hook, csv_pth, f = CSP11.get_reporting_hook(pth, domain)
+
+res = simulate_reservoir(case,
+    output_path = pth,
+    max_timestep = 1*si_unit(:year),
+    report_level = 0,
+    tol_cnv = 0.001,
+    post_ministep_hook = hook,
+    relaxation = SimpleRelaxation(),
+    max_nonlinear_iterations = 20,
+    max_timestep_cuts = 100,
+    info_level = 1
+)
+ws, states = res;
+
+  

--- a/docker_run_mrst_grid_spe11.jl
+++ b/docker_run_mrst_grid_spe11.jl
@@ -1,26 +1,34 @@
 using Jutul, JutulDarcy, HYPRE, CSP11
 
-basename = "cPEBI_2640x380"
-basename = "cPEBI_819x117"
-basename = "horizon-cut_100x50"
+basename = "cPEBI_2640x380"; specase = :b
+basename = "cPEBI_819x117"; specase = :b
+basename = "horizon-cut_100x50"; specase = :b
 
-case, name = setup_spe11_caseb_from_mrst_grid(basename, thermal = true);
+kg = :tpfa
+
+case, name = setup_spe11_case_from_mrst_grid(basename, case = specase, thermal = true, nstep_initialization = 0, use_reporting_steps = false, kgrad = kg);
 pth = jutul_output_path(name, subfolder = "csp11")
 domain = reservoir_domain(case.model)
 
-hook, csv_pth, f = CSP11.get_reporting_hook(pth, domain)
-
-res = simulate_reservoir(case,
+hook, csv_pth, f = CSP11.get_reporting_hook(pth, domain);
+sim, config = setup_reservoir_simulator(case,
     output_path = pth,
     max_timestep = 1*si_unit(:year),
     report_level = 0,
-    tol_cnv = 0.001,
+    tol_cnv = 0.01,
+    nonlinear_tolerance = Inf,
     post_ministep_hook = hook,
     relaxation = SimpleRelaxation(),
     max_nonlinear_iterations = 20,
     max_timestep_cuts = 100,
-    info_level = 1
-)
+    target_ds = 0.1,
+    info_level = 3
+);
+##
+res = simulate_reservoir(case,
+    simulator = sim,
+    config = config,
+);
 ws, states = res;
 
   


### PR DESCRIPTION
Using `julia` docker to run spe11 jutul runner, disabling rendering.
Here are items that are added by this PR:

- [x] An example `Dockerfile` based on _julia_ specific Docker image
- [x] A documentation in Readme to use it 
- [x] A julia runner that comment out rendering part

The example `Dockerfile` has to be amended prior to merge (as for now it explicitly point to this branch).

On [jafranc/feat/mesh_gen](https://github.com/jafranc/CSP11_JutulDarcy.jl/tree/feat/mesh_gen) there is an attempt to provide in addition a generic cartesian mesh generator leveraging _MRST_ tools. This might be a good addition to this PR but needs refactoring with a better knowledge of both Jutul and MRST and their interconnexions.
